### PR TITLE
README.md: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 
 ## НАСТОЯВАМЕ:
 
-### Да бъде отворен програмният код и на вече същестуващите софтуерни системи, разработени за нуждите на българските институции, както го направиха Великобритания[[2]](https://www.gov.uk/guidance/be-open-and-use-open-source?fbclid=IwAR1P4jJBMmVDwrV7xJ0_L55qR7xJ8iBPVrgIgIQ_Fcwb9laA_almFiaIhg8), Германия[[3]](https://opensource.com/article/18/4/news-april-28?fbclid=IwAR0YRVlhC9Y9flr8IWNkK07ak0IWBInbRtujN_KOx9pf9ePTeWiUM3j6ES0), Израел[[4]](https://www.haaretz.com/israel-news/business/israeli-government-shifting-its-software-code-to-open-source-1.6009259), Естония[[5]](http://www.h-online.com/open/news/item/Estonian-Government-publishes-open-source-policy-1097623.html) и десетки други държави [[6]](https://en.wikipedia.org/wiki/Adoption_of_free_and_open-source_software_by_public_institutions). 
+### Да бъде отворен програмният код и на вече съществуващите софтуерни системи, разработени за нуждите на българските институции, както го направиха Великобритания[[2]](https://www.gov.uk/guidance/be-open-and-use-open-source?fbclid=IwAR1P4jJBMmVDwrV7xJ0_L55qR7xJ8iBPVrgIgIQ_Fcwb9laA_almFiaIhg8), Германия[[3]](https://opensource.com/article/18/4/news-april-28?fbclid=IwAR0YRVlhC9Y9flr8IWNkK07ak0IWBInbRtujN_KOx9pf9ePTeWiUM3j6ES0), Израел[[4]](https://www.haaretz.com/israel-news/business/israeli-government-shifting-its-software-code-to-open-source-1.6009259), Естония[[5]](http://www.h-online.com/open/news/item/Estonian-Government-publishes-open-source-policy-1097623.html) и десетки други държави [[6]](https://en.wikipedia.org/wiki/Adoption_of_free_and_open-source_software_by_public_institutions). 
 
 Така специалистите, които биха могли да допринесат за подобряване качеството на софтуерните разработки, ще могат да дадат своя принос, като това ще се отрази положително и върху сигурността на продуктите. Мнозина от нас са готови да помогнат на доброволни начала, водени единствено от патриотични подбуди.
 
 По данни на БСК, всяка година от 2002 дo днес, България дава средно пo около 150 милиoнa лeвa гoдишнo национални и европейски средства зa въвeждaнe нa електронно управление [[7]](https://www.bia-bg.com/news/view/23682/). По всяка вероятност досега са похарчени около два и половина милиарда лева. Искаме да знаем къде са отишли парите ни!
 
 ## Отворете кода:
-* за да можем да гарантираме сигурността му 
+* за да можем да гарантираме сигурността му
 * за да можем да контролираме качеството му
 * за да можем да го подобрим
 
@@ -26,4 +26,4 @@
 
 Справка: според Закона за електронното управление (чл. 58а, ал. 1), компютърните програми трябва да отговарят на критериите за софтуер с отворен код, вижте [тук](https://www.lex.bg/laws/ldoc/2135555445). Настоящата петиция призовава за спазването на закона и за разширяване на обхвата му.
 
-### [Тук](https://github.com/otvorete/petition/stargazers) можете да видите подписалите петицията. 
+### [Тук](https://github.com/otvorete/petition/stargazers) можете да видите подписалите петицията.


### PR DESCRIPTION
Fix typo: "съществуващите" instead of "същестуващите".

Signed-off-by: Leon Anavi <leon@anavi.org>